### PR TITLE
Add logo strip and services sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,45 @@
         <h1>ElpiSoftware</h1>
     </header>
     <main>
-        <p>Hoşgeldiniz! ElpiSoftware'a giriş yaptınız.</p>
+        <section class="hero">
+            <p>Hoşgeldiniz! ElpiSoftware'a giriş yaptınız.</p>
+        </section>
+
+        <section class="logo-strip">
+            <div class="container">
+                <h2>BİZE GÜVENENLER</h2>
+                <div class="logos-container">
+                    <img src="https://via.placeholder.com/150x50?text=Logo+1" alt="Client logo 1">
+                    <img src="https://via.placeholder.com/150x50?text=Logo+2" alt="Client logo 2">
+                    <img src="https://via.placeholder.com/150x50?text=Logo+3" alt="Client logo 3">
+                    <img src="https://via.placeholder.com/150x50?text=Logo+4" alt="Client logo 4">
+                    <img src="https://via.placeholder.com/150x50?text=Logo+5" alt="Client logo 5">
+                </div>
+            </div>
+        </section>
+
+        <section class="services">
+            <div class="container">
+                <h2>Ürünleştirilmiş Hizmetlerimiz</h2>
+                <div class="services-grid">
+                    <div class="service-card">
+                        <div class="service-icon"></div>
+                        <h3>B2B Satış Odaklı Landing Tasarımı</h3>
+                        <p>İlk günden dönüşüm getirecek, satış odaklı açılış sayfası tasarımı ve teslimi.</p>
+                    </div>
+                    <div class="service-card">
+                        <div class="service-icon"></div>
+                        <h3>Startup’lar için Logo ve Temel Kimlik Paketi</h3>
+                        <p>Markanızın hikayesini anlatan logo, renk, tipografi ve temel kurumsal kimlik kılavuzu.</p>
+                    </div>
+                    <div class="service-card">
+                        <div class="service-icon"></div>
+                        <h3>Teknik SEO Temel Paketi</h3>
+                        <p>Sitenizin arama motoru sağlığını tarama, meta optimizasyonu ve hız önerileri ile iyileştirin.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
     </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add logo strip section with placeholder client logos for social proof
- introduce productized services section featuring three service cards

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68991b87b4a48329bb3ecd880600e000